### PR TITLE
Issue/19 Removes dismiss functionality from no product error.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -163,13 +163,37 @@ add_filter( 'affwp_notify_on_new_referral', 'affwp_allowed_products_notify_on_ne
  */
 function affwp_allowed_products_admin_notice() {
 
-    if ( ! affwp_allowed_products_get_products() ) { ?>
-	    <div class="error notice">
-		    <p><?php echo sprintf( __( 'There are currently no products configured to generate commissions. Visit the <a href="%s">Integrations</a> screen to enter some product IDs under the Allowed Products section.', 'affiliatewp-allowed-products' ), esc_url( admin_url( 'admin.php?page=affiliate-wp-settings&tab=integrations' ) ) ); ?></p>
-	    </div>
-		<?php }
+	$has_dismissed = get_user_meta( get_current_user_id(), '_affwp_no_allowed_products_dismissed', true );
+
+	if ( ! affwp_allowed_products_get_products() && ! $has_dismissed ) { ?>
+		<div class="error notice">
+			<p><?php echo sprintf( __( 'There are currently no products configured to generate commissions. Visit the <a href="%s">Integrations</a> screen to enter some product IDs under the Allowed Products section.', 'affiliatewp-allowed-products' ), esc_url( admin_url( 'admin.php?page=affiliate-wp-settings&tab=integrations' ) ) ); ?></p>
+			<p><a href="<?php echo wp_nonce_url( add_query_arg( array(
+					'affwp_action' => 'dismiss_notices',
+					'affwp_notice' => 'no_allowed_products',
+				) ), 'affwp_dismiss_notice', 'affwp_dismiss_notice_nonce' ); ?>"><?php _e( 'Dismiss Notice', 'affiliate-wp' ); ?></a>
+			</p>
+		</div>
+	<?php }
 }
+
 add_action( 'admin_notices', 'affwp_allowed_products_admin_notice' );
+
+/**
+ * Handles marking the allowed products notice as dismissed.
+ *
+ * @since 1.1
+ * @deprecated 1.1.3 No longer used by internal code and not recommended.
+ *
+ * @param string $notice Notice ID.
+ */
+function affwp_allowed_products_mark_notice_dismissed( $notice ) {
+	_deprecated_function( 'affwp_allowed_products_mark_notice_dismissed', '1.1.3' );
+
+	if ( 'no_allowed_products' === $notice ) {
+		update_user_meta( get_current_user_id(), '_affwp_no_allowed_products_dismissed', 1 );
+	}
+}
 
 /**
  * Retrieves a list of integrations that support Allowed Products.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -163,16 +163,9 @@ add_filter( 'affwp_notify_on_new_referral', 'affwp_allowed_products_notify_on_ne
  */
 function affwp_allowed_products_admin_notice() {
 
-	$has_dismissed = get_user_meta( get_current_user_id(), '_affwp_no_allowed_products_dismissed', true );
-
-	if ( ! affwp_allowed_products_get_products() && ! $has_dismissed ) { ?>
+	if ( ! affwp_allowed_products_get_products() ) { ?>
 		<div class="error notice">
 			<p><?php echo sprintf( __( 'There are currently no products configured to generate commissions. Visit the <a href="%s">Integrations</a> screen to enter some product IDs under the Allowed Products section.', 'affiliatewp-allowed-products' ), esc_url( admin_url( 'admin.php?page=affiliate-wp-settings&tab=integrations' ) ) ); ?></p>
-			<p><a href="<?php echo wp_nonce_url( add_query_arg( array(
-					'affwp_action' => 'dismiss_notices',
-					'affwp_notice' => 'no_allowed_products',
-				) ), 'affwp_dismiss_notice', 'affwp_dismiss_notice_nonce' ); ?>"><?php _e( 'Dismiss Notice', 'affiliate-wp' ); ?></a>
-			</p>
 		</div>
 	<?php }
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -163,30 +163,13 @@ add_filter( 'affwp_notify_on_new_referral', 'affwp_allowed_products_notify_on_ne
  */
 function affwp_allowed_products_admin_notice() {
 
-	$has_dismissed = get_user_meta( get_current_user_id(), '_affwp_no_allowed_products_dismissed', true );
-
-    if ( ! affwp_allowed_products_get_products() && ! $has_dismissed ) { ?>
-        <div class="error notice">
-            <p><?php echo sprintf( __( 'There are currently no products configured to generate commissions. Visit the <a href="%s">Integrations</a> screen to enter some product IDs under the Allowed Products section.', 'affiliatewp-allowed-products' ), esc_url( admin_url( 'admin.php?page=affiliate-wp-settings&tab=integrations' ) ) ); ?></p>
-			<p><a href="<?php echo wp_nonce_url( add_query_arg( array( 'affwp_action' => 'dismiss_notices', 'affwp_notice' => 'no_allowed_products' ) ), 'affwp_dismiss_notice', 'affwp_dismiss_notice_nonce' ); ?>"><?php _e( 'Dismiss Notice', 'affiliate-wp' ); ?></a></p>
-        </div>
-    <?php }
+    if ( ! affwp_allowed_products_get_products() ) { ?>
+	    <div class="error notice">
+		    <p><?php echo sprintf( __( 'There are currently no products configured to generate commissions. Visit the <a href="%s">Integrations</a> screen to enter some product IDs under the Allowed Products section.', 'affiliatewp-allowed-products' ), esc_url( admin_url( 'admin.php?page=affiliate-wp-settings&tab=integrations' ) ) ); ?></p>
+	    </div>
+		<?php }
 }
 add_action( 'admin_notices', 'affwp_allowed_products_admin_notice' );
-
-/**
- * Handles marking the allowed products notice as dismissed.
- *
- * @since 1.1
- *
- * @param string $notice Notice ID.
- */
-function affwp_allowed_products_mark_notice_dismissed( $notice ) {
-	if ( 'no_allowed_products' === $notice ) {
-		update_user_meta( get_current_user_id(), '_affwp_no_allowed_products_dismissed', 1 );
-	}
-}
-add_action( 'affwp_dismiss_notices_default', 'affwp_allowed_products_mark_notice_dismissed' );
 
 /**
  * Retrieves a list of integrations that support Allowed Products.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -126,6 +126,7 @@ add_filter( 'affwp_settings_integrations_sanitize', 'affwp_allowed_products_sani
  * if the product is blocked from receiving commission
  *
  * @since 1.0.1
+ * @since 1.1.3 The dismiss notice link was removed.
  */
 function affwp_allowed_products_notify_on_new_referral( $return, $referral ) {
 


### PR DESCRIPTION
Issue #19 

This removes the ability to dismiss a nag when there are no products allowed.